### PR TITLE
Fix bug with hidden_to_memory and no hidden_cell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,9 @@ repos:
     rev: 20.8b0
     hooks:
     - id: black
+      files: \.py$
+-   repo: https://github.com/pycqa/isort
+    rev: 5.6.4
+    hooks:
+      - id: isort
+        files: \.py$

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,13 @@ Release history
 0.3.1 (unreleased)
 ==================
 
+**Changed**
+
+- Raise a validation error if ``hidden_to_memory`` or ``input_to_hidden`` are True
+  when ``hidden_cell=None``. (`#26`_)
+
+.. _#26: https://github.com/nengo/keras-lmu/pull/26
+
 
 0.3.0 (November 6, 2020)
 ========================

--- a/keras_lmu/__init__.py
+++ b/keras_lmu/__init__.py
@@ -1,11 +1,6 @@
 """KerasLMU provides a package for deep learning with Legendre Memory Units."""
 
-from .layers import (
-    LMUCell,
-    LMUFFT,
-    LMU,
-)
-
+from .layers import LMU, LMUFFT, LMUCell
 from .version import version as __version__
 
 __copyright__ = "2019-2020, Applied Brain Research"

--- a/keras_lmu/layers.py
+++ b/keras_lmu/layers.py
@@ -3,8 +3,8 @@ Core classes for the KerasLMU package.
 """
 
 import numpy as np
-from scipy.signal import cont2discrete
 import tensorflow as tf
+from scipy.signal import cont2discrete
 from tensorflow.python.keras.layers.recurrent import DropoutRNNCellMixin
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,7 @@ requires = ["setuptools", "wheel"]
 
 [tool.black]
 target-version = ['py35', 'py36', 'py37', 'py38']
+
+[tool.isort]
+profile = "black"
+src_paths = ["keras_lmu"]


### PR DESCRIPTION
There was an error if `hidden_to_memory=True` and `hidden_cell=None` (since there is no hidden state to direct to the memory input). This handles that case. Note that this is technically equivalent to `memory_to_memory=True`, so it's kind of a weird thing to do, but I thought it was worth supporting so that people doing parameter sweeps and things like that can see the effect of this case rather than having to particularly avoid it.