### PR TITLE
Fix LMU swapping behaviour during training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ keras_lmu.egg-info
 __pycache__
 /.idea
 /docs/_build
+/tmp

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,12 @@ Release history
 - Raise a validation error if ``hidden_to_memory`` or ``input_to_hidden`` are True
   when ``hidden_cell=None``. (`#26`_)
 
+**Fixed**
+
+- Fixed a bug with the autoswapping in ``keras_lmu.LMU`` during training. (`#28`_)
+
 .. _#26: https://github.com/nengo/keras-lmu/pull/26
+.. _#28: https://github.com/nengo/keras-lmu/pull/28
 
 
 0.3.0 (November 6, 2020)


### PR DESCRIPTION
In some situations (e.g. calling `.fit` with `None` for the time dimension) the layer gets called with a mix of defined and undefined input steps, which messes up the autoswapping logic in `keras_lmu.LMU` (between the RNN and FFT implementations). This changes it so that the swap type is fixed at build time.

Fixes #27 