### PR TITLE
Reset dropout masks in hidden cell

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,9 +30,12 @@ Release history
 **Fixed**
 
 - Fixed a bug with the autoswapping in ``keras_lmu.LMU`` during training. (`#28`_)
+- Fixed a bug where dropout mask was not being reset properly in the hidden cell.
+  (`#29`_)
 
 .. _#26: https://github.com/nengo/keras-lmu/pull/26
 .. _#28: https://github.com/nengo/keras-lmu/pull/28
+.. _#29: https://github.com/nengo/keras-lmu/pull/29
 
 
 0.3.0 (November 6, 2020)

--- a/keras_lmu/layers.py
+++ b/keras_lmu/layers.py
@@ -243,6 +243,18 @@ class LMUCell(DropoutRNNCellMixin, tf.keras.layers.Layer):
 
         return o, h + [m]
 
+    def reset_dropout_mask(self):
+        """Reset dropout mask for memory and hidden components."""
+        super().reset_dropout_mask()
+        if isinstance(self.hidden_cell, DropoutRNNCellMixin):
+            self.hidden_cell.reset_dropout_mask()
+
+    def reset_recurrent_dropout_mask(self):
+        """Reset recurrent dropout mask for memory and hidden components."""
+        super().reset_recurrent_dropout_mask()
+        if isinstance(self.hidden_cell, DropoutRNNCellMixin):
+            self.hidden_cell.reset_recurrent_dropout_mask()
+
     def get_config(self):
         """Return config of layer (for serialization during model saving/loading)."""
 


### PR DESCRIPTION
Previously the dropout mask was only being reset for the hidden component, so the hidden component would always have the same dropout mask applied.