### PR TITLE
added memory_d>1 functionality

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Release history
 0.3.2 (unreleased)
 ==================
 
+**Added**
+
+- Setting ``kernel_initializer=None`` now removes the dense input kernel. (`#40`_)
+
+.. _#40: https://github.com/nengo/keras-lmu/pull/40
 
 0.3.1 (November 16, 2020)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ Release history
 **Added**
 
 - Setting ``kernel_initializer=None`` now removes the dense input kernel. (`#40`_)
+- The ``keras_lmu.LMUFFT`` layer now supports ``memory_d > 1``. ``keras_lmu.LMU`` now
+  uses this implementation for all values of ``memory_d`` when feedforward conditions
+  are satisfied (no hidden-to-memory or memory-to-memory connections,
+  and the sequence length is not ``None``). (`#40`_)
 
 .. _#40: https://github.com/nengo/keras-lmu/pull/40
 

--- a/keras_lmu/tests/test_layers.py
+++ b/keras_lmu/tests/test_layers.py
@@ -58,7 +58,7 @@ def test_multivariate_lmu(rng):
 
     for i in range(memory_d):
         assert np.allclose(
-            results[0][..., i * order : (i + 1) * order], results[i + 1], atol=1e-6
+            results[0][..., i * order : (i + 1) * order], results[i + 1], atol=2e-6
         )
 
 


### PR DESCRIPTION
LMUFFT should now be able to handle memory_d > 1, i.e, the input need not be projected down to a scalar before being fed into the delay layer.