### PR TITLE
Perform LMUFFT with raw convolution

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -65,7 +65,7 @@ travis_yml:
     TF_VERSION: tensorflow
   jobs:
     - script: static
-    - script: test
+    - script: remote-test
     - script: test
       env:
         TF_VERSION: tensorflow==2.1.0
@@ -95,6 +95,19 @@ ci_scripts:
     pip_install:
       - $TF_VERSION
   - template: remote-script
+    remote_script: test
+    output_name: remote-test
+    host: azure
+    travis_var_key: 2895d60e3414
+    azure_name: nengo-dl
+    azure_group: nengo-ci
+    coverage: true
+    remote_vars:
+      TF_FORCE_GPU_ALLOW_GROWTH: "true"
+      TF_VERSION: $TF_VERSION
+    remote_setup:
+      - conda install -y -c conda-forge cudatoolkit=11.3 cudnn=8.2
+  - template: remote-script
     remote_script: docs
     output_name: remote-docs
     host: azure-docs
@@ -102,7 +115,7 @@ ci_scripts:
     azure_name: nengo-dl-docs
     azure_group: nengo-ci
     remote_setup:
-      - conda install -y -c conda-forge cudatoolkit=11.2 cudnn=8.1
+      - conda install -y -c conda-forge cudatoolkit=11.3 cudnn=8.2
   - template: remote-script
     remote_script: examples
     output_name: remote-examples
@@ -111,7 +124,7 @@ ci_scripts:
     azure_name: nengo-dl-examples
     azure_group: nengo-ci
     remote_setup:
-      - conda install -y -c conda-forge cudatoolkit=11.2 cudnn=8.1
+      - conda install -y -c conda-forge cudatoolkit=11.3 cudnn=8.2
   - template: deploy
 
 codecov_yml: {}

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -22,7 +22,7 @@ setup_py:
     - pytest>=6.1.0
     - pytest-rng>=1.0.0
   docs_req:
-    - matplotlib>=3.0.2
+    - matplotlib>=3.0.2,<3.4.3
     - jupyter>=1.0.0
     - seaborn>=0.9.0
     - sphinx>=1.8

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -15,6 +15,7 @@ manifest_in: {}
 
 setup_py:
   install_req:
+    - packaging>=20.9
     - scipy>=1.0.0
     - tensorflow>=2.1.0
   tests_req:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       SCRIPT="static"
   -
     env:
-      SCRIPT="test"
+      SCRIPT="remote-test"
   -
     env:
       TF_VERSION="tensorflow==2.1.0"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,11 @@ Release history
   and ``B`` LMU matrices. This is mainly useful in combination with
   ``trainable_theta=True``, where setting ``discretizer="euler"`` may improve the
   training speed (possibly at the cost of some accuracy). (`#41`_)
+- The ``keras_lmu.LMUFFT`` layer can now use raw convolution internally (as opposed to
+  FFT-based convolution). The new ``conv_mode`` option exposes this. The new
+  ``truncate_ir`` option allows truncating the impulse response when running with a
+  raw convolution mode, for efficiency. Whether FFT-based or raw convolution is faster
+  depends on the specific model, hardware, and amount of truncation. (`#42`_)
 
 **Changed**
 
@@ -44,6 +49,7 @@ Release history
 
 .. _#40: https://github.com/nengo/keras-lmu/pull/40
 .. _#41: https://github.com/nengo/keras-lmu/pull/41
+.. _#42: https://github.com/nengo/keras-lmu/pull/42
 
 0.3.1 (November 16, 2020)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,10 @@ Release history
   weights from previous versions will be incompatible. (`#41`_)
 - Renamed ``keras_lmu.LMUFFT`` to ``keras_lmu.LMUFeedforward``. (`#42`_)
 
+**Fixed**
+
+- Fixed dropout support in TensorFlow 2.6. (`#42`_)
+
 .. _#40: https://github.com/nengo/keras-lmu/pull/40
 .. _#41: https://github.com/nengo/keras-lmu/pull/41
 .. _#42: https://github.com/nengo/keras-lmu/pull/42

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Release history
 - The ``A`` and ``B`` matrices are now stored as constants instead of non-trainable
   variables. This can improve the training/inference speed, but it means that saved
   weights from previous versions will be incompatible. (`#41`_)
+- Renamed ``keras_lmu.LMUFFT`` to ``keras_lmu.LMUFeedforward``. (`#42`_)
 
 .. _#40: https://github.com/nengo/keras-lmu/pull/40
 .. _#41: https://github.com/nengo/keras-lmu/pull/41

--- a/keras_lmu/__init__.py
+++ b/keras_lmu/__init__.py
@@ -1,6 +1,6 @@
 """KerasLMU provides a package for deep learning with Legendre Memory Units."""
 
-from .layers import LMU, LMUFFT, LMUCell
+from .layers import LMU, LMUCell, LMUFeedforward
 from .version import version as __version__
 
 __copyright__ = "2019-2021, Applied Brain Research"

--- a/keras_lmu/layers.py
+++ b/keras_lmu/layers.py
@@ -516,7 +516,7 @@ class LMU(tf.keras.layers.Layer):
         if self.built:
             return (
                 self.layer.theta
-                if isinstance(self.layer, LMUFFT)
+                if isinstance(self.layer, LMUFeedforward)
                 else self.layer.cell.theta
             )
 
@@ -541,7 +541,7 @@ class LMU(tf.keras.layers.Layer):
             and input_shapes[1] is not None
             and not self.trainable_theta
         ):
-            self.layer = LMUFFT(
+            self.layer = LMUFeedforward(
                 memory_d=self.memory_d,
                 order=self.order,
                 theta=self._init_theta,
@@ -620,15 +620,14 @@ class LMU(tf.keras.layers.Layer):
         return super().from_config(config)
 
 
-class LMUFFT(tf.keras.layers.Layer):
+class LMUFeedforward(tf.keras.layers.Layer):
     """
-    Layer class for the FFT variant of the LMU.
+    Layer class for the feedforward variant of the LMU.
 
     This class assumes no recurrent connections are desired in the memory component.
 
     Produces the output of the delay system by evaluating the convolution of the input
-    sequence with the impulse response from the LMU cell. The convolution operation is
-    calculated using the fast Fourier transform (FFT).
+    sequence with the impulse response from the LMU cell.
 
     Parameters
     ----------
@@ -749,8 +748,8 @@ class LMUFFT(tf.keras.layers.Layer):
             # TODO: we could dynamically run the impulse response for longer if
             #  needed using stateful=True
             raise ValueError(
-                f"LMUFFT requires that the input shape's temporal axis be fully "
-                f"specified (got {seq_len})"
+                f"LMUFeedforward requires that the input shape's temporal axis be "
+                f"fully specified (got {seq_len})"
             )
 
         impulse = tf.reshape(tf.eye(seq_len, 1), (1, -1, 1))

--- a/keras_lmu/layers.py
+++ b/keras_lmu/layers.py
@@ -4,7 +4,12 @@ Core classes for the KerasLMU package.
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.keras.layers.recurrent import DropoutRNNCellMixin
+from packaging import version
+
+if version.parse(tf.__version__) < version.parse("2.6.0rc0"):
+    from tensorflow.python.keras.layers.recurrent import DropoutRNNCellMixin
+else:
+    from keras.layers.recurrent import DropoutRNNCellMixin
 
 
 class LMUCell(DropoutRNNCellMixin, tf.keras.layers.Layer):

--- a/keras_lmu/tests/__init__.py
+++ b/keras_lmu/tests/__init__.py
@@ -1,0 +1,18 @@
+# pylint: disable=missing-docstring
+
+import subprocess
+import sys
+
+# check if GPU support is available
+# note: we run this in a subprocess because list_physical_devices()
+# will fix certain process-level TensorFlow configuration
+# options the first time it is called
+tf_gpu_installed = not subprocess.call(
+    [
+        sys.executable,
+        "-c",
+        "import sys; "
+        "import tensorflow as tf; "
+        "sys.exit(len(tf.config.list_physical_devices('GPU')) == 0)",
+    ]
+)

--- a/keras_lmu/tests/test_benchmarks.py
+++ b/keras_lmu/tests/test_benchmarks.py
@@ -50,7 +50,9 @@ def test_performance(mode, capsys):
             return_sequences=False,
         )
     elif mode in ("fft", "raw"):
-        lmu_layer = layers.LMUFFT(return_sequences=False, conv_mode=mode, **kwargs)
+        lmu_layer = layers.LMUFeedforward(
+            return_sequences=False, conv_mode=mode, **kwargs
+        )
 
     inputs = tf.keras.layers.Input((seq_len, dims), batch_size=batch_size)
     lmu = lmu_layer(inputs)

--- a/keras_lmu/tests/test_benchmarks.py
+++ b/keras_lmu/tests/test_benchmarks.py
@@ -1,0 +1,75 @@
+# pylint: disable=missing-docstring
+
+import timeit
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from keras_lmu import layers
+from keras_lmu.tests import tf_gpu_installed
+
+
+class SteptimeLogger(tf.keras.callbacks.Callback):
+    """Callback that records step times."""
+
+    def __init__(self, count_mode="samples", stateful_metrics=None):
+        super().__init__()
+
+        self.train_start = None
+        self.inference_start = None
+
+        self.train_times = []
+        self.inference_times = []
+
+    def on_train_batch_begin(self, batch, logs=None):
+        self.train_start = timeit.default_timer()
+
+    def on_train_batch_end(self, batch, logs=None):
+        self.train_times.append(timeit.default_timer() - self.train_start)
+
+    def on_predict_batch_begin(self, batch, logs=None):
+        self.inference_start = timeit.default_timer()
+
+    def on_predict_batch_end(self, batch, logs=None):
+        self.inference_times.append(timeit.default_timer() - self.inference_start)
+
+
+@pytest.mark.skipif(not tf_gpu_installed, reason="Very slow on CPU")
+@pytest.mark.parametrize("mode", ["rnn", "fft", "raw"])
+def test_performance(mode, capsys):
+    dims = 32
+    seq_len = 1024
+    batch_size = 32
+    odims = 2
+
+    kwargs = dict(memory_d=dims, order=256, theta=784, hidden_cell=None)
+    if mode == "rnn":
+        lmu_layer = tf.keras.layers.RNN(
+            layers.LMUCell(**kwargs),
+            return_sequences=False,
+        )
+    elif mode in ("fft", "raw"):
+        lmu_layer = layers.LMUFFT(return_sequences=False, conv_mode=mode, **kwargs)
+
+    inputs = tf.keras.layers.Input((seq_len, dims), batch_size=batch_size)
+    lmu = lmu_layer(inputs)
+    outputs = tf.keras.layers.Dense(odims)(lmu)
+
+    model = tf.keras.Model(inputs=inputs, outputs=outputs)
+
+    n_train = 20 * batch_size
+    x_train = tf.random.uniform((n_train, seq_len, dims), minval=-1, maxval=1, seed=0)
+    y_train = tf.random.uniform((n_train, odims), minval=-1, maxval=1, seed=1)
+    model.compile(
+        loss="mse",
+        optimizer=tf.keras.optimizers.RMSprop(),
+    )
+
+    steptimes = SteptimeLogger()
+    model.fit(x_train, y_train, epochs=1, batch_size=batch_size, callbacks=[steptimes])
+    model.predict(x_train, batch_size=batch_size, callbacks=[steptimes])
+
+    with capsys.disabled():
+        print(f"train step time: {np.min(steptimes.train_times):0.4f}")
+        print(f"inference step time: {np.min(steptimes.inference_times):0.4f}")

--- a/keras_lmu/tests/test_layers.py
+++ b/keras_lmu/tests/test_layers.py
@@ -223,7 +223,8 @@ def test_save_load_serialization(mode, tmp_path, trainable_theta, discretizer):
 )
 @pytest.mark.parametrize("memory_d", [1, 4])
 @pytest.mark.parametrize("discretizer", ("zoh", "euler"))
-def test_fft(return_sequences, hidden_cell, memory_d, discretizer, rng):
+@pytest.mark.parametrize("conv_mode", ["fft", "raw"])
+def test_fft(return_sequences, hidden_cell, memory_d, discretizer, conv_mode, rng):
     kwargs = dict(
         memory_d=memory_d,
         order=2,
@@ -240,12 +241,39 @@ def test_fft(return_sequences, hidden_cell, memory_d, discretizer, rng):
     )
     rnn_out = rnn_layer(x)
 
-    fft_layer = layers.LMUFFT(return_sequences=return_sequences, **kwargs)
+    fft_layer = layers.LMUFFT(
+        return_sequences=return_sequences, conv_mode=conv_mode, **kwargs
+    )
     fft_layer.build(x.shape)
     fft_layer.kernel.assign(rnn_layer.cell.kernel)
     fft_out = fft_layer(x, training=None)
 
     assert np.allclose(rnn_out, fft_out, atol=2e-6)
+
+
+@pytest.mark.parametrize("truncate_ir", [None, 1e-5, 1e-4, 1e-3])
+def test_raw_truncation(truncate_ir, rng):
+    seq_len = 64
+    theta = 11.2
+    kwargs = dict(
+        memory_d=4, order=4, theta=theta, hidden_cell=None, kernel_initializer=None
+    )
+
+    x = rng.uniform(-1, 1, size=(2, seq_len, kwargs["memory_d"]))
+
+    rnn_layer = tf.keras.layers.RNN(layers.LMUCell(**kwargs), return_sequences=True)
+    rnn_out = rnn_layer(x)
+
+    fft_layer = layers.LMUFFT(
+        return_sequences=True, conv_mode="raw", truncate_ir=truncate_ir, **kwargs
+    )
+    fft_out = fft_layer(x)
+    if truncate_ir is not None:
+        assert fft_layer.impulse_response.shape[0] < seq_len
+
+    # only one seed in 50 failed with `atol=truncate_ir`, hence the 1.2 fudge factor
+    atol = 2e-6 if truncate_ir is None else 1.2 * truncate_ir
+    assert np.allclose(rnn_out, fft_out, atol=atol)
 
 
 def test_validation_errors():
@@ -261,6 +289,9 @@ def test_validation_errors():
 
     with pytest.raises(ValueError, match="input_to_hidden must be False"):
         layers.LMUFFT(1, 2, 3, None, input_to_hidden=True)
+
+    with pytest.raises(ValueError, match="Unrecognized conv mode"):
+        layers.LMUFFT(1, 2, 3, None, conv_mode="raw_bad")
 
 
 @pytest.mark.parametrize(

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ root = pathlib.Path(__file__).parent
 version = runpy.run_path(str(root / "keras_lmu" / "version.py"))["version"]
 
 install_req = [
+    "packaging>=20.9",
     "scipy>=1.0.0",
     "tensorflow>=2.1.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_req = [
     "tensorflow>=2.1.0",
 ]
 docs_req = [
-    "matplotlib>=3.0.2",
+    "matplotlib>=3.0.2,<3.4.3",
     "jupyter>=1.0.0",
     "seaborn>=0.9.0",
     "sphinx>=1.8",


### PR DESCRIPTION
Add the ability to run the impulse response convolution as a raw convolution, rather than using the FFT. In practice, I've found that this can speed things up, though it also appears to require more CPU memory (which is surprising).

I also added a profiling test.

Based on #40.

TODO:
- [x] Figure out why this uses more CPU memory in some of our larger models (I have an example). Update: I looked into this, but was unable to reproduce the problem. I was trying on different hardware, though (the GPU I originally ran on was unavailable), so it's possible that's part of it. That said, I don't see any reason that the raw conv approach should use more memory (unless perhaps there's poorly-implemented explicit padding), so I'm not too worried about this.
- [x] Have the profiling test assert something, or make it an optional test/benchmark
- [x] Look into using shorter impulse responses when we have shorter theta. This is where this approach could really shine.