### PR TITLE
Update test for TF 2.7

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -108,6 +108,7 @@ ci_scripts:
       TF_VERSION: $TF_VERSION
     remote_setup:
       - conda install -y -c conda-forge cudatoolkit=11.3 cudnn=8.2
+      - export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$CONDA_PREFIX/lib
   - template: remote-script
     remote_script: docs
     output_name: remote-docs
@@ -117,6 +118,7 @@ ci_scripts:
     azure_group: nengo-ci
     remote_setup:
       - conda install -y -c conda-forge cudatoolkit=11.3 cudnn=8.2
+      - export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$CONDA_PREFIX/lib
   - template: remote-script
     remote_script: examples
     output_name: remote-examples
@@ -126,6 +128,7 @@ ci_scripts:
     azure_group: nengo-ci
     remote_setup:
       - conda install -y -c conda-forge cudatoolkit=11.3 cudnn=8.2
+      - export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$CONDA_PREFIX/lib
   - template: deploy
 
 codecov_yml: {}

--- a/keras_lmu/tests/test_layers.py
+++ b/keras_lmu/tests/test_layers.py
@@ -331,14 +331,16 @@ def test_feedforward_auto_swap(
     (tf.keras.layers.SimpleRNNCell(units=10), tf.keras.layers.Dense(units=10), None),
 )
 @pytest.mark.parametrize("feedforward", (True, False))
-def test_hidden_types(hidden_cell, feedforward, rng, seed):
+def test_hidden_types(hidden_cell, feedforward, rng):
     x = rng.uniform(-1, 1, size=(2, 5, 32))
 
     lmu_params = dict(
         memory_d=1,
         order=3,
         theta=4,
-        kernel_initializer=tf.keras.initializers.glorot_uniform(seed=seed),
+        kernel_initializer=tf.keras.initializers.constant(
+            rng.uniform(-1, 1, size=(32, 1))
+        ),
     )
 
     base_lmu = tf.keras.layers.RNN(
@@ -365,7 +367,9 @@ def test_hidden_types(hidden_cell, feedforward, rng, seed):
     )
     lmu_output = lmu(x)
 
-    assert np.allclose(lmu_output, base_output, atol=2e-6 if feedforward else 1e-8)
+    assert np.allclose(
+        lmu_output, base_output, atol=2e-6 if feedforward else 1e-8
+    ), np.max(np.abs(lmu_output - base_output))
 
 
 @pytest.mark.parametrize("feedforward", (True, False))


### PR DESCRIPTION
No changes required in the code itself, but one of the tests was failing. The test was using seeded weight initializers to ensure that different layers had the same weights, but that behaviour appears to be broken in TF 2.7 (see https://github.com/keras-team/keras/issues/15586). So I switched the way the initialization works in that test so that it doesn't depend on TensorFlow's RNG.