### PR TITLE
Support unknown sequence lengths in LMUFeedforward

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -81,7 +81,7 @@ ci_scripts:
       TF_FORCE_GPU_ALLOW_GROWTH: "true"
       TF_VERSION: $TF_VERSION
     remote_setup:
-      - micromamba install -y "$TF_VERSION"
+      - micromamba install -y "$TF_VERSION" cudnn=8.4
   - template: remote-script
     remote_script: docs
     output_name: remote-docs
@@ -89,7 +89,7 @@ ci_scripts:
     azure_name: nengo-dl-docs
     azure_group: nengo-ci
     remote_setup:
-      - micromamba install -y "$TF_VERSION"
+      - micromamba install -y "$TF_VERSION" cudnn=8.4
   - template: remote-script
     remote_script: examples
     output_name: remote-examples
@@ -97,7 +97,7 @@ ci_scripts:
     azure_name: nengo-dl-examples
     azure_group: nengo-ci
     remote_setup:
-      - micromamba install -y "$TF_VERSION"
+      - micromamba install -y "$TF_VERSION" cudnn=8.4
   - template: deploy
     wheel: true
 

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -108,6 +108,6 @@ pyproject_toml: {}
 version_py:
   type: semver
   major: 0
-  minor: 5
-  patch: 1
+  minor: 6
+  patch: 0
   release: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Release history
 - ``LMUFeedforward`` can now be used with unknown sequence lengths, and ``LMU`` will
   use ``LMUFeedforward`` for unknown sequence lengths (as long as the other conditions
   are met, as before). (`#52`_)
+- Allow ``input_to_hidden=True`` with ``hidden_cell=None``. This will act as a skip
+  connection. (`#52`_)
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ Release history
    - Removed
    - Fixed
 
-0.5.1 (unreleased)
+0.6.0 (unreleased)
 ==================
 
 *Compatible with TensorFlow 2.4 - 2.11*
@@ -31,6 +31,8 @@ Release history
   are met, as before). (`#52`_)
 - Allow ``input_to_hidden=True`` with ``hidden_cell=None``. This will act as a skip
   connection. (`#52`_)
+- Changed order of LMU states so that the LMU memory state always comes first, and
+  any states from the hidden cell come afterwards. (`#52`_)
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,18 @@ Release history
 
 *Compatible with TensorFlow 2.4 - 2.11*
 
+**Changed**
+
+- ``LMUFeedforward`` can now be used with unknown sequence lengths, and ``LMU`` will
+  use ``LMUFeedforward`` for unknown sequence lengths (as long as the other conditions
+  are met, as before). (`#52`_)
+
+**Fixed**
+
+- Fixed errors when setting non-default dtype on LMU layers. (`#52`_)
+
+.. _#52: https://github.com/nengo/keras-lmu/pull/52
+
 0.5.0 (January 26, 2023)
 ========================
 

--- a/keras_lmu/layers.py
+++ b/keras_lmu/layers.py
@@ -230,7 +230,7 @@ class LMUCell(DropoutRNNCellMixin, BaseRandomLayer):
         """
 
         # combine A/B and pad to make square matrix
-        em_upper = tf.concat([A, B], axis=0)
+        em_upper = tf.concat([A, B], axis=0)  # pylint: disable=no-value-for-parameter
         em = tf.pad(em_upper, [(0, 0), (0, B.shape[0])])
 
         # compute matrix exponential
@@ -334,7 +334,11 @@ class LMUCell(DropoutRNNCellMixin, BaseRandomLayer):
         m = states[-1]
 
         # compute memory input
-        u = tf.concat((inputs, h[0]), axis=1) if self.hidden_to_memory else inputs
+        u = (
+            tf.concat((inputs, h[0]), axis=1)  # pylint: disable=no-value-for-parameter
+            if self.hidden_to_memory
+            else inputs
+        )
         if self.dropout > 0:
             u *= self.get_dropout_mask_for_cell(u, training)
         if self.kernel is not None:
@@ -383,7 +387,11 @@ class LMUCell(DropoutRNNCellMixin, BaseRandomLayer):
         m = tf.reshape(m, (-1, self.memory_d * self.order))
 
         # apply hidden cell
-        h_in = tf.concat((m, inputs), axis=1) if self.input_to_hidden else m
+        h_in = (
+            tf.concat((m, inputs), axis=1)  # pylint: disable=no-value-for-parameter
+            if self.input_to_hidden
+            else m
+        )
 
         if self.hidden_cell is None:
             o = h_in
@@ -595,7 +603,7 @@ class LMU(tf.keras.layers.Layer):
 
         return self._init_theta
 
-    def build(self, input_shapes):
+    def build(self, input_shape):
         """
         Builds the layer.
 
@@ -606,7 +614,7 @@ class LMU(tf.keras.layers.Layer):
         with some additional bookkeeping.
         """
 
-        super().build(input_shapes)
+        super().build(input_shape)
 
         if (
             not self.hidden_to_memory
@@ -656,7 +664,7 @@ class LMU(tf.keras.layers.Layer):
                 dtype=self.dtype,
             )
 
-        self.layer.build(input_shapes)
+        self.layer.build(input_shape)
 
     def call(self, inputs, training=None):
         """
@@ -961,7 +969,11 @@ class LMUFeedforward(tf.keras.layers.Layer):
             m = self._raw_convolution(u)
 
         # apply hidden cell
-        h_in = tf.concat((m, inputs), axis=-1) if self.input_to_hidden else m
+        h_in = (
+            tf.concat((m, inputs), axis=-1)  # pylint: disable=no-value-for-parameter
+            if self.input_to_hidden
+            else m
+        )
 
         if self.hidden_cell is None:
             h = h_in if self.return_sequences else h_in[:, -1]

--- a/keras_lmu/layers.py
+++ b/keras_lmu/layers.py
@@ -156,9 +156,10 @@ class LMUCell(DropoutRNNCellMixin, BaseRandomLayer):
             )
 
         if self.hidden_cell is None:
-            for conn in ("hidden_to_memory", "input_to_hidden"):
-                if getattr(self, conn):
-                    raise ValueError(f"{conn} must be False if hidden_cell is None")
+            if self.hidden_to_memory:
+                raise ValueError(
+                    "hidden_to_memory must be False if hidden_cell is None"
+                )
 
             self.hidden_output_size = self.memory_d * self.order
             self.hidden_state_size = []
@@ -801,9 +802,6 @@ class LMUFeedforward(tf.keras.layers.Layer):
         **kwargs,
     ):
         super().__init__(**kwargs)
-
-        if input_to_hidden and hidden_cell is None:
-            raise ValueError("input_to_hidden must be False if hidden_cell is None")
 
         if conv_mode not in ("fft", "raw"):
             raise ValueError(f"Unrecognized conv mode '{conv_mode}'")

--- a/keras_lmu/layers.py
+++ b/keras_lmu/layers.py
@@ -171,9 +171,9 @@ class LMUCell(DropoutRNNCellMixin, BaseRandomLayer):
             self.hidden_output_size = self.hidden_cell.units
             self.hidden_state_size = [self.hidden_cell.units]
 
-        self.state_size = tf.nest.flatten(self.hidden_state_size) + [
-            self.memory_d * self.order
-        ]
+        self.state_size = [self.memory_d * self.order] + tf.nest.flatten(
+            self.hidden_state_size
+        )
         self.output_size = self.hidden_output_size
 
     @property
@@ -329,10 +329,10 @@ class LMUCell(DropoutRNNCellMixin, BaseRandomLayer):
 
         states = tf.nest.flatten(states)
 
-        # state for the hidden cell
-        h = states[:-1]
         # state for the LMU memory
-        m = states[-1]
+        m = states[0]
+        # state for the hidden cell
+        h = states[1:]
 
         # compute memory input
         u = (
@@ -403,7 +403,7 @@ class LMUCell(DropoutRNNCellMixin, BaseRandomLayer):
             o = self.hidden_cell(h_in, training=training)
             h = [o]
 
-        return o, h + [m]
+        return o, [m] + h
 
     def reset_dropout_mask(self):
         """Reset dropout mask for memory and hidden components."""

--- a/keras_lmu/tests/test_layers.py
+++ b/keras_lmu/tests/test_layers.py
@@ -298,12 +298,6 @@ def test_validation_errors():
     with pytest.raises(ValueError, match="hidden_to_memory must be False"):
         layers.LMUCell(1, 2, 3, None, hidden_to_memory=True)
 
-    with pytest.raises(ValueError, match="input_to_hidden must be False"):
-        layers.LMUCell(1, 2, 3, None, input_to_hidden=True)
-
-    with pytest.raises(ValueError, match="input_to_hidden must be False"):
-        layers.LMUFeedforward(1, 2, 3, None, input_to_hidden=True)
-
     with pytest.raises(ValueError, match="Unrecognized conv mode"):
         layers.LMUFeedforward(1, 2, 3, None, conv_mode="raw_bad")
 

--- a/keras_lmu/tests/test_layers.py
+++ b/keras_lmu/tests/test_layers.py
@@ -734,8 +734,7 @@ def test_regularizer_loss(fft, bias):
 def test_get_config(cls):
     """Test that all ``__init__`` arguments appear in the ``get_config`` dictionary."""
 
-    params = {"memory_d": 2, "order": 5, "theta": 3.2, "hidden_cell": None}
-    obj = cls(**params)
+    obj = cls(memory_d=2, order=5, theta=3.2, hidden_cell=None)
 
     config = obj.get_config()
     sig = inspect.signature(cls.__init__)

--- a/keras_lmu/version.py
+++ b/keras_lmu/version.py
@@ -11,7 +11,7 @@ unless the code base represents a release version. Release versions are git
 tagged with the version.
 """
 
-version_info = (0, 5, 1)
+version_info = (0, 6, 0)
 
 name = "keras-lmu"
 dev = 0


### PR DESCRIPTION
Uses a heuristic of `3*theta` for the impulse response length if the sequence length is unknown.